### PR TITLE
use concurrent-ruby instead of atomic; atomic is deprecated.

### DIFF
--- a/lib/peek/views/redis.rb
+++ b/lib/peek/views/redis.rb
@@ -1,5 +1,5 @@
 require 'redis'
-require 'atomic'
+require 'concurrent'
 
 # Instrument Redis time
 module Peek
@@ -21,8 +21,8 @@ class Redis::Client
   class << self
     attr_accessor :query_time, :query_count
   end
-  self.query_count = Atomic.new(0)
-  self.query_time = Atomic.new(0)
+  self.query_count = ::Concurrent::AtomicFixnum.new(0)
+  self.query_time = ::Concurrent::AtomicFixnum.new(0)
 end
 
 module Peek

--- a/peek-redis.gemspec
+++ b/peek-redis.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'peek'
   gem.add_dependency 'redis'
-  gem.add_dependency 'atomic', '>= 1.0.0'
+  gem.add_dependency 'concurrent-ruby', '>= 1.0.0'
 end


### PR DESCRIPTION
https://github.com/ruby-concurrency/atomic is deprecated and its readme says "use concurrent-ruby instead."

